### PR TITLE
set the correct default model name for anthropic

### DIFF
--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -6,7 +6,7 @@ from anthropic import AsyncAnthropic, Anthropic
 from typing import Optional
 
 class Anthropic(ModelProvider):
-    def __init__(self, model_name: str = "claude", api_key: str = None):
+    def __init__(self, model_name: str = "claude-2.1", api_key: str = None):
         """
         :param model_name: The name of the model. Default is 'claude'.
         :param api_key: The API key for Anthropic. Default is None.


### PR DESCRIPTION
Updated the default name of Anthropic mode, `claude` --> `claude-2.1`. There is no model named `claude`

Anthropic released Claude 3 yesterday but kept 2.1 as default since Greg originally tested on this version.

With this change, I can run the Anthropic test.  :+1: 