### PR TITLE
 Fixed a typo in evaluation function

### DIFF
--- a/needlehaystack/evaluators/openai.py
+++ b/needlehaystack/evaluators/openai.py
@@ -13,7 +13,7 @@ class OpenAIEvaluator(Evaluator):
                 Score 5: The answer has moderate relevance but contains inaccuracies.
                 Score 7: The answer aligns with the reference but has minor omissions.
                 Score 10: The answer is completely accurate and aligns perfectly with the reference.
-                Only respond with a numberical score"""}
+                Only respond with a numerical score"""}
 
     def __init__(self,
                  model_name: str = "gpt-3.5-turbo-0125",

--- a/needlehaystack/llm_needle_haystack_tester.py
+++ b/needlehaystack/llm_needle_haystack_tester.py
@@ -278,38 +278,6 @@ class LLMNeedleHaystackTester:
         new_context = self.model_to_test.decode_tokens(tokens_new_context)
         return new_context
 
-    def evaluate_response(self, response):
-        accuracy_criteria = {
-            "accuracy": """
-            Score 1: The answer is completely unrelated to the reference.
-            Score 3: The answer has minor relevance but does not align with the reference.
-            Score 5: The answer has moderate relevance but contains inaccuracies.
-            Score 7: The answer aligns with the reference but has minor omissions.
-            Score 10: The answer is completely accurate and aligns perfectly with the reference.
-            Only respond with a numerical score
-            """
-        }
-
-        # Using GPT-4 to evaluate
-        evaluator = load_evaluator(
-            "labeled_score_string",
-            criteria=accuracy_criteria,
-            llm=self.evaluation_model,
-        )
-
-        eval_result = evaluator.evaluate_strings(
-            # The models response
-            prediction=response,
-
-            # The actual answer
-            reference=self.needle,
-
-            # The question asked
-            input=self.retrieval_question,
-        )
-
-        return int(eval_result['score'])
-
     def get_context_length_in_tokens(self, context):
         return len(self.model_to_test.encode_text_to_tokens(context))
 


### PR DESCRIPTION
As I was going through the code to understand what the evaluation was doing, I encountered this typo.
This affects the whole evaluation process and might bias the results.

This is why I would consider incorporating this change.

NB: this is a follow-up PR of "Fixed a typo in evaluation function #9"