### PR TITLE
Updated Anthropic to use message API (instead of completion API) - resolves #13 

### DIFF
--- a/needlehaystack/providers/Anthropic_prompt.txt
+++ b/needlehaystack/providers/Anthropic_prompt.txt
@@ -1,9 +1,0 @@
-You are a helpful AI bot that answers questions for a user. Keep your response short and direct
-
-Human: <context>
-{context}
-</context>
-
-{retrieval_question} Don't give information outside the document or repeat your findings
-
-Assistant: Here is the most relevant sentence in the context:


### PR DESCRIPTION
this pull request is for #13 

- Update Anthropic code to match the OpenAI code in setting up prompts

- This change is needed because text completion API is deprecated and recommendation is to use message API
[refer here](https://docs.anthropic.com/claude/reference/complete_post)

- Removed Anthropic_prompt.txt file, since prompt is included in anthropic.py