### PR TITLE
Three Line Change to Add Support for Local Models, OpenRouter and Other OpenAI Compatible Providers

### DIFF
--- a/needlehaystack/config/schema.py
+++ b/needlehaystack/config/schema.py
@@ -40,6 +40,7 @@ class ModelClient(BaseModel):
     """SDK client construction inputs (mostly auth)."""
 
     api_key_env: str | None = None
+    base_url_env: str | None = None
 
     model_config = ConfigDict(extra="allow")
 

--- a/needlehaystack/providers/openai.py
+++ b/needlehaystack/providers/openai.py
@@ -61,7 +61,8 @@ def _build_openai(config: ModelConfig) -> OpenAIProvider:
     from openai import AsyncOpenAI  # lazy: only imported when the plugin runs
 
     api_key = os.environ.get(config.client.api_key_env) if config.client.api_key_env else None
-    client = AsyncOpenAI(api_key=api_key)
+    base_url = os.environ.get(config.client.base_url_env) if config.client.base_url_env else None
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
     # Forward every `request:` key except the ones we handle explicitly.
     # `stream` is stripped because our `complete()` returns a single
     # aggregated `Completion`, not a stream.


### PR DESCRIPTION
This adds support for another environment variable to configure the base url for the OpenAI provider. This unlocks support for both local models (tested via llama.cpp) and OpenRouter (also tested). It should also easily enable other OpenAI compatible model providers.

It adds support for a new key, `base_url_env`, in the `client` section of the model config. This should allow anyone to put a url for any OpenAI compatible local model server in the `.env` file. Tested examples for llama.cpp  and OpenRouter below.

### Llama.cpp

Example `client` section in the model config.
```yaml
client:
  api_key_env: "LLAMA_CPP_KEY"
  base_url_env: "LLAMA_CPP_URL"
```

Matching example `.env`
```.env
LLAMA_CPP_KEY="this_does_not_matter"
LLAMA_CPP_URL="http://127.0.0.1:8080/v1"
```

### OpenRouter

```yaml
client:
  api_key_env: "OPENROUTER_KEY"
  base_url_env: "OPENROUTER_URL"
```

```.env
OPENROUTER_KEY="sk-or-v1-this-is-a-fake-key-add-your-own-key-for-openrouter-here"
OPENROUTER_URL="https://openrouter.ai/api/v1"
```